### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,14 +60,14 @@
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>bukkit</artifactId>
-			<version>1.8.3-R0.1-SNAPSHOT</version>
+			<version>1.8.7-R0.1-SNAPSHOT</version>
 			<type>jar</type>
 		</dependency>
 
 		<dependency>
 			<groupId>net.milkbowl.vault</groupId>
 			<artifactId>Vault</artifactId>
-			<version>1.4.1</version>
+			<version>1.5</version>
 			<type>jar</type>
 		</dependency>
 


### PR DESCRIPTION
Compiles with Spigot 1.8.7. Versions below have security flaws; don't see why you'd keep it compiled with that version in general too.
Also updated Vault to 1.5